### PR TITLE
New option for shutdown grace period

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -171,6 +171,8 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		profilerPort = flags.Int("profiler-port", 10245, "Port to use for expose the ingress controller Go profiler when it is enabled.")
 
 		statusUpdateInterval = flags.Int("status-update-interval", status.UpdateInterval, "Time interval in seconds in which the status should check if an update is required. Default is 60 seconds")
+
+		shutdownGracePeriod = flags.Int("shutdown-grace-period", 0, "Time in seconds to wait after marked as shutting down before actual shutdown.")
 	)
 
 	flags.StringVar(&nginx.MaxmindLicenseKey, "maxmind-license-key", "", `Maxmind license key to download GeoLite2 Databases.
@@ -282,6 +284,7 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 		PublishService:         *publishSvc,
 		PublishStatusAddress:   *publishStatusAddress,
 		UpdateStatusOnShutdown: *updateStatusOnShutdown,
+		ShutdownGracePeriod:    *shutdownGracePeriod,
 		UseNodeInternalIP:      *useNodeInternalIP,
 		SyncRateLimit:          *syncRateLimit,
 		ListenPorts: &ngx_config.ListenPorts{

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -103,6 +103,8 @@ type Configuration struct {
 	MaxmindEditionFiles []string
 
 	MonitorMaxBatchSize int
+
+	ShutdownGracePeriod int
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -369,6 +369,7 @@ func (n *NGINXController) Start() {
 // Stop gracefully stops the NGINX master process.
 func (n *NGINXController) Stop() error {
 	n.isShuttingDown = true
+	time.Sleep(time.Duration(n.cfg.ShutdownGracePeriod) * time.Second)
 
 	n.stopLock.Lock()
 	defer n.stopLock.Unlock()


### PR DESCRIPTION
Adding flag `--shutdown-grace-period` to set a time in seconds from the point where the process marks itself as shutting down and the actual shutdown.